### PR TITLE
Replace fmt.Sprintf with equivalent strconv.Itoa

### DIFF
--- a/Documentation/learning/lock/client/client.go
+++ b/Documentation/learning/lock/client/client.go
@@ -26,14 +26,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"go.etcd.io/etcd/v3/clientv3"
-	"go.etcd.io/etcd/v3/clientv3/concurrency"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime"
 	"strconv"
 	"time"
+
+	"go.etcd.io/etcd/v3/clientv3"
+	"go.etcd.io/etcd/v3/clientv3/concurrency"
 )
 
 type node struct {

--- a/auth/metrics.go
+++ b/auth/metrics.go
@@ -15,8 +15,9 @@
 package auth
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/client/json.go
+++ b/client/json.go
@@ -15,10 +15,10 @@
 package client
 
 import (
-	"github.com/json-iterator/go"
-	"github.com/modern-go/reflect2"
 	"strconv"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 type customNumberExtension struct {

--- a/client/keys.go
+++ b/client/keys.go
@@ -19,12 +19,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go.etcd.io/etcd/v3/pkg/pathutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"go.etcd.io/etcd/v3/pkg/pathutil"
 )
 
 const (

--- a/clientv3/concurrency/example_stm_test.go
+++ b/clientv3/concurrency/example_stm_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"strconv"
 	"sync"
 
 	"go.etcd.io/etcd/v3/clientv3"
@@ -61,8 +62,8 @@ func ExampleSTM_apply() {
 		fromInt, toInt = fromInt-xfer, toInt+xfer
 
 		// write back
-		stm.Put(fromK, fmt.Sprintf("%d", fromInt))
-		stm.Put(toK, fmt.Sprintf("%d", toInt))
+		stm.Put(fromK, strconv.Itoa(fromInt))
+		stm.Put(toK, strconv.Itoa(toInt))
 		return nil
 	}
 

--- a/clientv3/integration/leasing_test.go
+++ b/clientv3/integration/leasing_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -978,7 +979,7 @@ func TestLeasingTxnRandIfThenOrElse(t *testing.T) {
 	keyCount := 16
 	dat := make([]*clientv3.PutResponse, keyCount)
 	for i := 0; i < keyCount; i++ {
-		k, v := fmt.Sprintf("k-%d", i), fmt.Sprintf("%d", i)
+		k, v := fmt.Sprintf("k-%d", i), strconv.Itoa(i)
 		dat[i], err1 = clus.Client(0).Put(context.TODO(), k, v)
 		if err1 != nil {
 			t.Fatal(err1)
@@ -1493,7 +1494,7 @@ func TestLeasingReconnectOwnerConsistency(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		v := fmt.Sprintf("%d", i)
+		v := strconv.Itoa(i)
 		donec := make(chan struct{})
 		clus.Members[0].DropConnections()
 		go func() {

--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -968,11 +968,11 @@ func TestWatchCancelOnServer(t *testing.T) {
 	cancels := make([]context.CancelFunc, numWatches)
 	for i := 0; i < numWatches; i++ {
 		// force separate streams in client
-		md := metadata.Pairs("some-key", fmt.Sprintf("%d", i))
+		md := metadata.Pairs("some-key", strconv.Itoa(i))
 		mctx := metadata.NewOutgoingContext(context.Background(), md)
 		ctx, cancel := context.WithCancel(mctx)
 		cancels[i] = cancel
-		w := client.Watch(ctx, fmt.Sprintf("%d", i), clientv3.WithCreatedNotify())
+		w := client.Watch(ctx, strconv.Itoa(i), clientv3.WithCreatedNotify())
 		<-w
 	}
 
@@ -1031,7 +1031,7 @@ func testWatchOverlapContextCancel(t *testing.T, f func(*integration.ClusterV3))
 	ctxs, ctxc := make([]context.Context, 5), make([]chan struct{}, 5)
 	for i := range ctxs {
 		// make unique stream
-		md := metadata.Pairs("some-key", fmt.Sprintf("%d", i))
+		md := metadata.Pairs("some-key", strconv.Itoa(i))
 		ctxs[i] = metadata.NewOutgoingContext(context.Background(), md)
 		// limits the maximum number of outstanding watchers per stream
 		ctxc[i] = make(chan struct{}, 2)

--- a/clientv3/snapshot/v3_snapshot_test.go
+++ b/clientv3/snapshot/v3_snapshot_test.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -265,7 +266,7 @@ func restoreCluster(t *testing.T, clusterN int, dbPath string) (
 		cfg := embed.NewConfig()
 		cfg.Logger = "zap"
 		cfg.LogOutputs = []string{"/dev/null"}
-		cfg.Name = fmt.Sprintf("%d", i)
+		cfg.Name = strconv.Itoa(i)
 		cfg.InitialClusterToken = testClusterTkn
 		cfg.ClusterState = "existing"
 		cfg.LCUrls, cfg.ACUrls = []url.URL{cURLs[i]}, []url.URL{cURLs[i]}

--- a/etcdctl/ctlv2/command/exec_watch_command.go
+++ b/etcdctl/ctlv2/command/exec_watch_command.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strconv"
 
 	"go.etcd.io/etcd/v3/client"
 
@@ -119,7 +120,7 @@ func execWatchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 func environResponse(resp *client.Response, env []string) []string {
 	env = append(env, "ETCD_WATCH_ACTION="+resp.Action)
-	env = append(env, "ETCD_WATCH_MODIFIED_INDEX="+fmt.Sprintf("%d", resp.Node.ModifiedIndex))
+	env = append(env, "ETCD_WATCH_MODIFIED_INDEX="+strconv.Itoa(resp.Node.ModifiedIndex))
 	env = append(env, "ETCD_WATCH_KEY="+resp.Node.Key)
 	env = append(env, "ETCD_WATCH_VALUE="+resp.Node.Value)
 	return env

--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/bgentry/speakeasy"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/bgentry/speakeasy"
 
 	"go.etcd.io/etcd/v3/clientv3"
 	"go.etcd.io/etcd/v3/clientv3/mirror"

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -15,7 +15,6 @@
 package etcdmain
 
 import (
-	"fmt"
 	"strconv"
 
 	"go.etcd.io/etcd/v3/embed"
@@ -162,8 +161,8 @@ Security:
 Auth:
   --auth-token 'simple'
     Specify a v3 authentication token type and its options ('simple' or 'jwt').
-  --bcrypt-cost ` + fmt.Sprintf("%d", bcrypt.DefaultCost) + `
-    Specify the cost / strength of the bcrypt algorithm for hashing auth passwords. Valid values are between ` + fmt.Sprintf("%d", bcrypt.MinCost) + ` and ` + fmt.Sprintf("%d", bcrypt.MaxCost) + `.
+  --bcrypt-cost ` + strconv.Itoa(bcrypt.DefaultCost) + `
+    Specify the cost / strength of the bcrypt algorithm for hashing auth passwords. Valid values are between ` + strconv.Itoa(bcrypt.MinCost) + ` and ` + strconv.Itoa(bcrypt.MaxCost) + `.
 
 Profiling and Monitoring:
   --enable-pprof 'false'

--- a/etcdserver/api/membership/member.go
+++ b/etcdserver/api/membership/member.go
@@ -17,9 +17,9 @@ package membership
 import (
 	"crypto/sha1"
 	"encoding/binary"
-	"fmt"
 	"math/rand"
 	"sort"
+	"strconv"
 	"time"
 
 	"go.etcd.io/etcd/v3/pkg/types"
@@ -75,7 +75,7 @@ func newMember(name string, peerURLs types.URLs, clusterName string, now *time.T
 
 	b = append(b, []byte(clusterName)...)
 	if now != nil {
-		b = append(b, []byte(fmt.Sprintf("%d", now.Unix()))...)
+		b = append(b, []byte(strconv.Itoa(now.Unix()))...)
 	}
 
 	hash := sha1.Sum(b)

--- a/etcdserver/api/v3election/v3electionpb/gw/v3election.pb.gw.go
+++ b/etcdserver/api/v3election/v3electionpb/gw/v3election.pb.gw.go
@@ -9,9 +9,10 @@ It translates gRPC into RESTful JSON APIs.
 package gw
 
 import (
-	"go.etcd.io/etcd/v3/etcdserver/api/v3election/v3electionpb"
 	"io"
 	"net/http"
+
+	"go.etcd.io/etcd/v3/etcdserver/api/v3election/v3electionpb"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"

--- a/etcdserver/api/v3lock/v3lockpb/gw/v3lock.pb.gw.go
+++ b/etcdserver/api/v3lock/v3lockpb/gw/v3lock.pb.gw.go
@@ -9,9 +9,10 @@ It translates gRPC into RESTful JSON APIs.
 package gw
 
 import (
-	"go.etcd.io/etcd/v3/etcdserver/api/v3lock/v3lockpb"
 	"io"
 	"net/http"
+
+	"go.etcd.io/etcd/v3/etcdserver/api/v3lock/v3lockpb"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -312,7 +313,7 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 	cc := &http.Client{Transport: peerRt}
 	// TODO: refactor member http handler code
 	// cannot import etcdhttp, so manually construct url
-	requestUrl := url + "/members/promote/" + fmt.Sprintf("%d", id)
+	requestUrl := url + "/members/promote/" + strconv.Itoa(id)
 	req, err := http.NewRequest("POST", requestUrl, nil)
 	if err != nil {
 		return nil, err

--- a/etcdserver/etcdserverpb/gw/rpc.pb.gw.go
+++ b/etcdserver/etcdserverpb/gw/rpc.pb.gw.go
@@ -9,9 +9,10 @@ It translates gRPC into RESTful JSON APIs.
 package gw
 
 import (
-	"go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
 	"io"
 	"net/http"
+
+	"go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"

--- a/etcdserver/etcdserverpb/rpc.pb.go
+++ b/etcdserver/etcdserverpb/rpc.pb.go
@@ -104,7 +104,9 @@ var RangeRequest_SortTarget_value = map[string]int32{
 func (x RangeRequest_SortTarget) String() string {
 	return proto.EnumName(RangeRequest_SortTarget_name, int32(x))
 }
-func (RangeRequest_SortTarget) EnumDescriptor() ([]byte, []int) { return fileDescriptorRpc, []int{1, 1} }
+func (RangeRequest_SortTarget) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptorRpc, []int{1, 1}
+}
 
 type Compare_CompareResult int32
 

--- a/functional/rpcpb/etcd_config.go
+++ b/functional/rpcpb/etcd_config.go
@@ -17,6 +17,7 @@ package rpcpb
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -81,7 +82,7 @@ func (e *Etcd) Flags() (fs []string) {
 			}
 			sv = strings.Join(sl, ",")
 		case reflect.Int64:
-			sv = fmt.Sprintf("%d", fv.Int())
+			sv = strconv.Itoa(fv.Int())
 		case reflect.Bool:
 			sv = fmt.Sprintf("%v", fv.Bool())
 		default:

--- a/functional/rpcpb/rpc.pb.go
+++ b/functional/rpcpb/rpc.pb.go
@@ -7,14 +7,15 @@ import (
 	context "context"
 	encoding_binary "encoding/binary"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/functional/runner/election_command.go
+++ b/functional/runner/election_command.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"go.etcd.io/etcd/v3/clientv3/concurrency"
 
@@ -51,7 +52,7 @@ func runElectionFunc(cmd *cobra.Command, args []string) {
 	eps := endpointsFromFlag(cmd)
 
 	for i := range rcs {
-		v := fmt.Sprintf("%d", i)
+		v := strconv.Itoa(i)
 		observedLeader := ""
 		validateWaiters := 0
 		var rcNextc chan struct{}

--- a/functional/tester/case_external.go
+++ b/functional/tester/case_external.go
@@ -17,6 +17,7 @@ package tester
 import (
 	"fmt"
 	"os/exec"
+	"strconv"
 
 	"go.etcd.io/etcd/v3/functional/rpcpb"
 )
@@ -31,11 +32,11 @@ type caseExternal struct {
 }
 
 func (c *caseExternal) Inject(clus *Cluster) error {
-	return exec.Command(c.scriptPath, "enable", fmt.Sprintf("%d", clus.rd)).Run()
+	return exec.Command(c.scriptPath, "enable", strconv.Itoa(clus.rd)).Run()
 }
 
 func (c *caseExternal) Recover(clus *Cluster) error {
-	return exec.Command(c.scriptPath, "disable", fmt.Sprintf("%d", clus.rd)).Run()
+	return exec.Command(c.scriptPath, "disable", strconv.Itoa(clus.rd)).Run()
 }
 
 func (c *caseExternal) Desc() string {

--- a/functional/tester/checker_lease_expire.go
+++ b/functional/tester/checker_lease_expire.go
@@ -17,6 +17,7 @@ package tester
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"go.etcd.io/etcd/v3/clientv3"
@@ -224,7 +225,7 @@ func (lc *leaseExpireChecker) hasLeaseExpired(ctx context.Context, leaseID int64
 // Since the format of keys contains about leaseID, finding keys base on "<leaseID>" prefix
 // determines whether the attached keys for a given leaseID has been deleted or not
 func (lc *leaseExpireChecker) hasKeysAttachedToLeaseExpired(ctx context.Context, leaseID int64) (bool, error) {
-	resp, err := lc.cli.Get(ctx, fmt.Sprintf("%d", leaseID), clientv3.WithPrefix())
+	resp, err := lc.cli.Get(ctx, strconv.Itoa(leaseID), clientv3.WithPrefix())
 	if err != nil {
 		lc.lg.Warn(
 			"hasKeysAttachedToLeaseExpired failed",

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -71,7 +71,7 @@ func testClusterUsingDiscovery(t *testing.T, size int) {
 	dcc := MustNewHTTPClient(t, dc.URLs(), nil)
 	dkapi := client.NewKeysAPI(dcc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", size)); err != nil {
+	if _, err := dkapi.Create(ctx, "/_config/size", strconv.Itoa(size)); err != nil {
 		t.Fatal(err)
 	}
 	cancel()
@@ -94,7 +94,7 @@ func TestTLSClusterOf3UsingDiscovery(t *testing.T) {
 	dcc := MustNewHTTPClient(t, dc.URLs(), nil)
 	dkapi := client.NewKeysAPI(dcc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", 3)); err != nil {
+	if _, err := dkapi.Create(ctx, "/_config/size", strconv.Itoa(3)); err != nil {
 		t.Fatal(err)
 	}
 	cancel()

--- a/integration/v3_barrier_test.go
+++ b/integration/v3_barrier_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/v3/clientv3"
-	"go.etcd.io/etcd/v3/contrib/recipes"
 	"go.etcd.io/etcd/v3/pkg/testutil"
 )
 

--- a/integration/v3_double_barrier_test.go
+++ b/integration/v3_double_barrier_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/v3/clientv3/concurrency"
-	"go.etcd.io/etcd/v3/contrib/recipes"
 )
 
 func TestDoubleBarrier(t *testing.T) {

--- a/integration/v3_queue_test.go
+++ b/integration/v3_queue_test.go
@@ -17,10 +17,9 @@ package integration
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync/atomic"
 	"testing"
-
-	"go.etcd.io/etcd/v3/contrib/recipes"
 )
 
 const (
@@ -41,7 +40,7 @@ func TestQueueOneReaderOneWriter(t *testing.T) {
 		etcdc := clus.RandClient()
 		q := recipe.NewQueue(etcdc, "testq")
 		for i := 0; i < 5; i++ {
-			if err := q.Enqueue(fmt.Sprintf("%d", i)); err != nil {
+			if err := q.Enqueue(strconv.Itoa(i)); err != nil {
 				t.Errorf("error enqueuing (%v)", err)
 			}
 		}
@@ -54,7 +53,7 @@ func TestQueueOneReaderOneWriter(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error dequeueing (%v)", err)
 		}
-		if s != fmt.Sprintf("%d", i) {
+		if s != strconv.Itoa(i) {
 			t.Fatalf("expected dequeue value %v, got %v", s, i)
 		}
 	}
@@ -94,7 +93,7 @@ func TestPrQueueOneReaderOneWriter(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		// [0, 2] priority for priority collision to test seq keys
 		pr := uint16(rand.Intn(3))
-		if err := q.Enqueue(fmt.Sprintf("%d", pr), pr); err != nil {
+		if err := q.Enqueue(strconv.Itoa(pr), pr); err != nil {
 			t.Fatalf("error enqueuing (%v)", err)
 		}
 	}

--- a/integration/v3_stm_test.go
+++ b/integration/v3_stm_test.go
@@ -59,8 +59,8 @@ func TestSTMConflict(t *testing.T) {
 				return nil
 			}
 			xfer := int64(rand.Intn(int(srcV)) / 2)
-			stm.Put(srcKey, fmt.Sprintf("%d", srcV-xfer))
-			stm.Put(dstKey, fmt.Sprintf("%d", dstV+xfer))
+			stm.Put(srcKey, strconv.Itoa(srcV-xfer))
+			stm.Put(dstKey, strconv.Itoa(dstV+xfer))
 			return nil
 		}
 		go func() {
@@ -164,7 +164,7 @@ func TestSTMSerialize(t *testing.T) {
 	go func() {
 		defer close(updatec)
 		for i := 0; i < 5; i++ {
-			s := fmt.Sprintf("%d", i)
+			s := strconv.Itoa(i)
 			ops := []v3.Op{}
 			for _, k := range keys {
 				ops = append(ops, v3.OpPut(k, s))

--- a/integration/v3election_grpc_test.go
+++ b/integration/v3election_grpc_test.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -149,7 +150,7 @@ func TestV3ElectionObserve(t *testing.T) {
 			t.Error(cerr2)
 		}
 		for i := 6; i < 10; i++ {
-			v := []byte(fmt.Sprintf("%d", i))
+			v := []byte(strconv.Itoa(i))
 			req := &epb.ProclaimRequest{Leader: c2.Leader, Value: v}
 			if _, err := lc.Proclaim(context.TODO(), req); err != nil {
 				t.Error(err)
@@ -158,7 +159,7 @@ func TestV3ElectionObserve(t *testing.T) {
 	}()
 
 	for i := 1; i < 5; i++ {
-		v := []byte(fmt.Sprintf("%d", i))
+		v := []byte(strconv.Itoa(i))
 		req := &epb.ProclaimRequest{Leader: c1.Leader, Value: v}
 		if _, err := lc.Proclaim(context.TODO(), req); err != nil {
 			t.Fatal(err)

--- a/pkg/report/timeseries.go
+++ b/pkg/report/timeseries.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"math"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -127,11 +128,11 @@ func (t TimeSeries) String() string {
 	rows := [][]string{}
 	for i := range t {
 		row := []string{
-			fmt.Sprintf("%d", t[i].Timestamp),
+			strconv.Itoa(t[i].Timestamp),
 			t[i].MinLatency.String(),
 			t[i].AvgLatency.String(),
 			t[i].MaxLatency.String(),
-			fmt.Sprintf("%d", t[i].ThroughPut),
+			strconv.Itoa(t[i].ThroughPut),
 		}
 		rows = append(rows, row)
 	}

--- a/pkg/srv/srv.go
+++ b/pkg/srv/srv.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"go.etcd.io/etcd/v3/pkg/types"
@@ -52,7 +53,7 @@ func GetCluster(serviceScheme, service, name, dns string, apurls types.URLs) ([]
 			return err
 		}
 		for _, srv := range addrs {
-			port := fmt.Sprintf("%d", srv.Port)
+			port := strconv.Itoa(srv.Port)
 			host := net.JoinHostPort(srv.Target, port)
 			tcpAddr, terr := resolveTCPAddr("tcp", host)
 			if terr != nil {
@@ -65,7 +66,7 @@ func GetCluster(serviceScheme, service, name, dns string, apurls types.URLs) ([]
 				n = name
 			}
 			if n == "" {
-				n = fmt.Sprintf("%d", tempName)
+				n = strconv.Itoa(tempName)
 				tempName++
 			}
 			// SRV records have a trailing dot but URL shouldn't.
@@ -108,7 +109,7 @@ func GetClient(service, domain string, serviceName string) (*SRVClients, error) 
 		for _, srv := range addrs {
 			urls = append(urls, &url.URL{
 				Scheme: scheme,
-				Host:   net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port)),
+				Host:   net.JoinHostPort(srv.Target, strconv.Itoa(srv.Port)),
 			})
 		}
 		srvs = append(srvs, addrs...)

--- a/pkg/types/urlsmap_test.go
+++ b/pkg/types/urlsmap_test.go
@@ -15,9 +15,10 @@
 package types
 
 import (
-	"go.etcd.io/etcd/v3/pkg/testutil"
 	"reflect"
 	"testing"
+
+	"go.etcd.io/etcd/v3/pkg/testutil"
 )
 
 func TestParseInitialCluster(t *testing.T) {

--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -237,7 +238,7 @@ func (cfg *etcdProcessClusterConfig) etcdServerProcessConfigs() []*etcdServerPro
 			"--initial-advertise-peer-urls", purl.String(),
 			"--initial-cluster-token", cfg.initialToken,
 			"--data-dir", dataDirPath,
-			"--snapshot-count", fmt.Sprintf("%d", cfg.snapshotCount),
+			"--snapshot-count", strconv.Itoa(cfg.snapshotCount),
 		}
 		args = addV2Args(args)
 		if cfg.forceNewCluster {
@@ -245,7 +246,7 @@ func (cfg *etcdProcessClusterConfig) etcdServerProcessConfigs() []*etcdServerPro
 		}
 		if cfg.quotaBackendBytes > 0 {
 			args = append(args,
-				"--quota-backend-bytes", fmt.Sprintf("%d", cfg.quotaBackendBytes),
+				"--quota-backend-bytes", strconv.Itoa(cfg.quotaBackendBytes),
 			)
 		}
 		if cfg.noStrictReconfig {

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -15,7 +15,7 @@
 package e2e
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -381,5 +381,5 @@ func ctlV3GetWithErr(cx ctlCtx, args []string, errs []string) error {
 func ctlV3Del(cx ctlCtx, args []string, num int) error {
 	cmdArgs := append(cx.PrefixArgs(), "del")
 	cmdArgs = append(cmdArgs, args...)
-	return spawnWithExpects(cmdArgs, fmt.Sprintf("%d", num))
+	return spawnWithExpects(cmdArgs, strconv.Itoa(num))
 }

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"go.etcd.io/etcd/v3/version"
@@ -52,10 +53,10 @@ func metricsTest(cx ctlCtx) {
 		{"/health", `{"health":"true"}`},
 	} {
 		i++
-		if err := ctlV3Put(cx, fmt.Sprintf("%d", i), "v", ""); err != nil {
+		if err := ctlV3Put(cx, strconv.Itoa(i), "v", ""); err != nil {
 			cx.t.Fatal(err)
 		}
-		if err := ctlV3Del(cx, []string{fmt.Sprintf("%d", i)}, 1); err != nil {
+		if err := ctlV3Del(cx, []string{strconv.Itoa(i)}, 1); err != nil {
 			cx.t.Fatal(err)
 		}
 

--- a/tests/e2e/v2_curl_test.go
+++ b/tests/e2e/v2_curl_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -170,7 +171,7 @@ func cURLPrefixArgs(clus *etcdProcessCluster, method string, req cURLReq) []stri
 		cmdArgs = append(cmdArgs, "-L", ep)
 	}
 	if req.timeout != 0 {
-		cmdArgs = append(cmdArgs, "-m", fmt.Sprintf("%d", req.timeout))
+		cmdArgs = append(cmdArgs, "-m", strconv.Itoa(req.timeout))
 	}
 
 	if req.header != "" {

--- a/tools/benchmark/cmd/watch_get.go
+++ b/tools/benchmark/cmd/watch_get.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -56,7 +57,7 @@ func watchGetFunc(cmd *cobra.Command, args []string) {
 	// setup keys for watchers
 	watchRev := int64(0)
 	for i := 0; i < watchEvents; i++ {
-		v := fmt.Sprintf("%d", i)
+		v := strconv.Itoa(i)
 		resp, err := clients[0].Put(context.TODO(), "watchkey", v)
 		if err != nil {
 			panic(err)

--- a/tools/etcd-dump-db/backend.go
+++ b/tools/etcd-dump-db/backend.go
@@ -17,8 +17,9 @@ package main
 import (
 	"encoding/binary"
 	"fmt"
-	"go.etcd.io/etcd/v3/auth/authpb"
 	"path/filepath"
+
+	"go.etcd.io/etcd/v3/auth/authpb"
 
 	"go.etcd.io/etcd/v3/lease/leasepb"
 	"go.etcd.io/etcd/v3/mvcc"


### PR DESCRIPTION
This campaign replaces `fmt.Sprintf` with `strconv.Itoa`

[_Created by Sourcegraph campaign `christine/unity-sprintf-to-itoa`._](https://demo.sourcegraph.com/users/christine/campaigns/unity-sprintf-to-itoa)