### PR TITLE
Pin Docker `:latest` image tags to digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base-arm64:latest
+FROM k8s.gcr.io/debian-base-arm64:latest@sha256:b62dad17f41f53b7caa291477264eedf5286e9639bff87551bb9b7f960d62a4d
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
The `:latest` tag changes, so future pulls of this image may retrieve a different image with different (and possibly erroneous, unexpected, or dangerous) behavior. Pin the image to an [image digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier) for deterministic behavior. *See also: [Hadolint error DL3007](https://github.com/hadolint/hadolint/wiki/DL3007).*

[_Created by Sourcegraph batch change `christine/pin-docker-images-22`._](https://demo.sourcegraph.com/users/christine/batch-changes/pin-docker-images-22)