### PR TITLE
Add a cycling fun fact to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,7 @@ These emeritus maintainers dedicated a part of their career to etcd and reviewed
 
 etcd is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.
 Hello World 2
+
+## Cycling Fun Fact
+
+Did you know? In the 1989 Tour de France, Greg LeMond beat Laurent Fignon by just 8 seconds after more than 87 hours of racing - the closest finish in Tour history.


### PR DESCRIPTION
This change appends a fun fact about cycling to the README file(s) in this repository.

Part of a batch change rollout across the sourcegraph-testing org.

[_Created by Sourcegraph batch change `robert/ca78c9d6-0482-434b-a9de-c7158ec01efe`._](https://sourcegraph.test:3443/users/robert/batch-changes/ca78c9d6-0482-434b-a9de-c7158ec01efe)